### PR TITLE
Conv dto new end point

### DIFF
--- a/projArq/src/main/java/com/T1/projArq/application/dto/AplicativoDTO.java
+++ b/projArq/src/main/java/com/T1/projArq/application/dto/AplicativoDTO.java
@@ -10,6 +10,13 @@ public class AplicativoDTO {
     private Double custoMensal;
     private List<Assinatura> assinaturas;
 
+    public AplicativoDTO(Long codigo, String nome, Double custoMensal, List<Assinatura> assinaturas) {
+        this.codigo = codigo;
+        this.nome = nome;
+        this.custoMensal = custoMensal;
+        this.assinaturas = assinaturas;
+    }
+
     public Long getCodigo() {
         return this.codigo;
     }

--- a/projArq/src/main/java/com/T1/projArq/application/dto/AplicativoDTO.java
+++ b/projArq/src/main/java/com/T1/projArq/application/dto/AplicativoDTO.java
@@ -1,8 +1,7 @@
-package com.T1.projArq.aplication.dto;
+package com.T1.projArq.application.dto;
 
 import com.T1.projArq.domain.model.Assinatura;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class AplicativoDTO {

--- a/projArq/src/main/java/com/T1/projArq/application/dto/AssinaturaDTO.java
+++ b/projArq/src/main/java/com/T1/projArq/application/dto/AssinaturaDTO.java
@@ -1,4 +1,4 @@
-package com.T1.projArq.aplication.dto;
+package com.T1.projArq.application.dto;
 
 import com.T1.projArq.domain.model.Aplicativo;
 import com.T1.projArq.domain.model.Cliente;

--- a/projArq/src/main/java/com/T1/projArq/application/dto/ClienteDTO.java
+++ b/projArq/src/main/java/com/T1/projArq/application/dto/ClienteDTO.java
@@ -1,4 +1,4 @@
-package com.T1.projArq.aplication.dto;
+package com.T1.projArq.application.dto;
 
 public class ClienteDTO {
     private Long codigo;

--- a/projArq/src/main/java/com/T1/projArq/application/dto/ClienteDTO.java
+++ b/projArq/src/main/java/com/T1/projArq/application/dto/ClienteDTO.java
@@ -1,9 +1,21 @@
 package com.T1.projArq.application.dto;
 
+import com.T1.projArq.domain.model.Assinatura;
+
+import java.util.List;
+
 public class ClienteDTO {
     private Long codigo;
     private String nome;
     private String email;
+    private List<Assinatura> assinaturas;
+
+    public ClienteDTO(Long codigo, String nome, String email, List<Assinatura> assinaturas) {
+        this.codigo = codigo;
+        this.nome = nome;
+        this.email = email;
+        this.assinaturas = assinaturas.size() > 0 ? assinaturas : null;
+    }
 
     public Long getCodigo() {
         return codigo;
@@ -16,5 +28,6 @@ public class ClienteDTO {
     public String getNome() {
         return nome;
     }
+
 }
 

--- a/projArq/src/main/java/com/T1/projArq/application/dto/PagamentoDTO.java
+++ b/projArq/src/main/java/com/T1/projArq/application/dto/PagamentoDTO.java
@@ -8,6 +8,13 @@ public class PagamentoDTO {
     private Date dataPagamento;
     private String promocao;
 
+    public PagamentoDTO(Long assinaturaId, Double valorPago, Date dataPagamento, String promocao) {
+        this.assinaturaId = assinaturaId;
+        this.valorPago = valorPago;
+        this.dataPagamento = dataPagamento;
+        this.promocao = promocao;
+    }
+
     public Long getAssinaturaId() {
         return assinaturaId;
     }

--- a/projArq/src/main/java/com/T1/projArq/domain/model/Aplicativo.java
+++ b/projArq/src/main/java/com/T1/projArq/domain/model/Aplicativo.java
@@ -28,6 +28,10 @@ public class Aplicativo {
         return this.custoMensal;
     }
 
+    public List<Assinatura> getAssinaturas() {
+        return this.assinaturas;
+    }
+
     public void setCustoMensal(Double custoMensal) {
         this.custoMensal = custoMensal;
     }

--- a/projArq/src/main/java/com/T1/projArq/domain/model/Assinatura.java
+++ b/projArq/src/main/java/com/T1/projArq/domain/model/Assinatura.java
@@ -1,6 +1,9 @@
 package com.T1.projArq.domain.model;
 
-import java.util.*;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 public class Assinatura {
     private Long codigo;

--- a/projArq/src/main/java/com/T1/projArq/domain/repository/IAssinaturaRepository.java
+++ b/projArq/src/main/java/com/T1/projArq/domain/repository/IAssinaturaRepository.java
@@ -1,16 +1,15 @@
 package com.T1.projArq.domain.repository;
 
-import com.T1.projArq.domain.model.Aplicativo;
 import com.T1.projArq.domain.model.Assinatura;
 import com.T1.projArq.domain.model.Cliente;
 
-import java.util.Date;
 import java.util.List;
 
 public interface IAssinaturaRepository {
     Assinatura create(Assinatura assinatura, Cliente cliente);
     List<Assinatura> getAll();
     Assinatura getById(Long codigo);
+    List<Assinatura> getByAplicativoId(Long aplicativoId);
     void update(Assinatura assinatura);
     void delete(Long codigo);
 }

--- a/projArq/src/main/java/com/T1/projArq/domain/services/AplicativoService.java
+++ b/projArq/src/main/java/com/T1/projArq/domain/services/AplicativoService.java
@@ -1,4 +1,4 @@
-package com.T1.projArq.aplication;
+package com.T1.projArq.domain.services;
 
 import com.T1.projArq.domain.model.Aplicativo;
 import com.T1.projArq.domain.repository.IAplicativoRepository;

--- a/projArq/src/main/java/com/T1/projArq/domain/services/AplicativoService.java
+++ b/projArq/src/main/java/com/T1/projArq/domain/services/AplicativoService.java
@@ -1,5 +1,6 @@
 package com.T1.projArq.domain.services;
 
+import com.T1.projArq.application.dto.AplicativoDTO;
 import com.T1.projArq.domain.model.Aplicativo;
 import com.T1.projArq.domain.repository.IAplicativoRepository;
 import org.springframework.stereotype.Service;
@@ -21,19 +22,24 @@ public class AplicativoService {
     }
 
     // Recupera todos os aplicativos
-    public List<Aplicativo> getAllAplicativos() {
-        return this.aplicativoRepository.getAll();
+    public List<AplicativoDTO> getAllAplicativos() {
+        List<Aplicativo> aplicativos = this.aplicativoRepository.getAll();
+        return aplicativos.stream().map(this::toDTO).toList();
     }
 
     // Recupera um aplicativo por id
     public Aplicativo getById(Long codigo) { return this.aplicativoRepository.getById(codigo); }
 
     // Atualiza o custo mensal de um aplicativo
-    public Aplicativo updateCusto(Long codigo, Double custoMensal) {
+    public AplicativoDTO updateCusto(Long codigo, Double custoMensal) {
         Aplicativo aplicativo = aplicativoRepository.getById(codigo);
         aplicativo.setCustoMensal(custoMensal);
         this.aplicativoRepository.update(aplicativo);
-        return aplicativo;
+        return toDTO(aplicativo);
     }
 
+
+    private AplicativoDTO toDTO(Aplicativo aplicativo) {
+        return new AplicativoDTO(aplicativo.getCodigo(), aplicativo.getNome(), aplicativo.getCustoMensal(), aplicativo.getAssinaturas());
+    }
 }

--- a/projArq/src/main/java/com/T1/projArq/domain/services/AssinaturaService.java
+++ b/projArq/src/main/java/com/T1/projArq/domain/services/AssinaturaService.java
@@ -189,17 +189,7 @@ public class AssinaturaService {
     public List<AssinaturaDTO> getAssinaturasByAplicativo(Long codapp) {
         List<Assinatura> assinaturas = assinaturaDataBase.getByAplicativoId(codapp);
 
-        return assinaturas.stream()
-                .map(assinatura -> new AssinaturaDTO(
-                        assinatura.getCodigo(),
-                        assinatura.getInicioVigencia(),
-                        assinatura.getFimVigencia(),
-                        assinatura.getPagamentos(),
-                        assinatura.getAplicativo(),
-                        assinatura.getCliente(),
-                        (assinatura.getFimVigencia() != null && new Date().before(assinatura.getFimVigencia())) ? "ATIVA" : "CANCELADA" // Status
-                ))
-                .collect(Collectors.toList());
+      return assinaturas.stream().map(this::toDTO).toList();
     }
 
 
@@ -208,4 +198,17 @@ public class AssinaturaService {
 
         return assinatura.getFimVigencia() != null && new Date().before(assinatura.getFimVigencia()) ? true : false;
     }
+
+    private AssinaturaDTO toDTO(Assinatura assinatura) {
+        return new AssinaturaDTO(
+                assinatura.getCodigo(),
+                assinatura.getInicioVigencia(),
+                assinatura.getFimVigencia(),
+                assinatura.getPagamentos(),
+                assinatura.getAplicativo(),
+                assinatura.getCliente(),
+                (assinatura.getFimVigencia() != null && new Date().before(assinatura.getFimVigencia())) ? "ATIVA" : "CANCELADA" // Status
+        );
+    }
 }
+

--- a/projArq/src/main/java/com/T1/projArq/domain/services/AssinaturaService.java
+++ b/projArq/src/main/java/com/T1/projArq/domain/services/AssinaturaService.java
@@ -1,15 +1,12 @@
 package com.T1.projArq.domain.services;
 
-import com.T1.projArq.aplication.AplicativoService;
-import com.T1.projArq.aplication.ClienteService;
-import com.T1.projArq.aplication.dto.AssinaturaDTO;
+import com.T1.projArq.application.dto.AssinaturaDTO;
 import com.T1.projArq.domain.model.Aplicativo;
 import com.T1.projArq.domain.model.Assinatura;
 import com.T1.projArq.domain.model.Cliente;
 import com.T1.projArq.interfaceAdaptors.infrastructure.dataBase.AssinaturaDataBase;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
 
 import java.util.Calendar;
 import java.util.Date;
@@ -20,8 +17,8 @@ import java.util.stream.Collectors;
 public class AssinaturaService {
 
     private final AssinaturaDataBase assinaturaDataBase;
-    private final com.T1.projArq.aplication.ClienteService clienteService;
-    private final com.T1.projArq.aplication.AplicativoService aplicativoService;
+    private final ClienteService clienteService;
+    private final AplicativoService aplicativoService;
 
     @Autowired
     public AssinaturaService(AssinaturaDataBase assinaturaDataBase, ClienteService clienteService, AplicativoService aplicativoService) {
@@ -188,6 +185,23 @@ public class AssinaturaService {
                 ))
                 .collect(Collectors.toList());
     }
+
+    public List<AssinaturaDTO> getAssinaturasByAplicativo(Long codapp) {
+        List<Assinatura> assinaturas = assinaturaDataBase.getByAplicativoId(codapp);
+
+        return assinaturas.stream()
+                .map(assinatura -> new AssinaturaDTO(
+                        assinatura.getCodigo(),
+                        assinatura.getInicioVigencia(),
+                        assinatura.getFimVigencia(),
+                        assinatura.getPagamentos(),
+                        assinatura.getAplicativo(),
+                        assinatura.getCliente(),
+                        (assinatura.getFimVigencia() != null && new Date().before(assinatura.getFimVigencia())) ? "ATIVA" : "CANCELADA" // Status
+                ))
+                .collect(Collectors.toList());
+    }
+
 
     public Boolean isAssinaturaAtiva(Long codass) {
         Assinatura assinatura = assinaturaDataBase.getById(codass);

--- a/projArq/src/main/java/com/T1/projArq/domain/services/ClienteService.java
+++ b/projArq/src/main/java/com/T1/projArq/domain/services/ClienteService.java
@@ -1,15 +1,12 @@
-package com.T1.projArq.aplication;
+package com.T1.projArq.domain.services;
 
-import com.T1.projArq.domain.model.Aplicativo;
-import com.T1.projArq.domain.model.Assinatura;
 import com.T1.projArq.domain.model.Cliente;
 import com.T1.projArq.domain.repository.IAplicativoRepository;
 import com.T1.projArq.domain.repository.IAssinaturaRepository;
 import com.T1.projArq.domain.repository.IClienteRepository;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.*;
+import org.springframework.stereotype.Service;
 
-import java.util.Date;
 import java.util.List;
 
 @Service

--- a/projArq/src/main/java/com/T1/projArq/domain/services/ClienteService.java
+++ b/projArq/src/main/java/com/T1/projArq/domain/services/ClienteService.java
@@ -1,5 +1,6 @@
 package com.T1.projArq.domain.services;
 
+import com.T1.projArq.application.dto.ClienteDTO;
 import com.T1.projArq.domain.model.Cliente;
 import com.T1.projArq.domain.repository.IAplicativoRepository;
 import com.T1.projArq.domain.repository.IAssinaturaRepository;
@@ -29,8 +30,9 @@ public class ClienteService {
     }
 
     // Recupera todos os clientes
-    public List<Cliente> getAllClientes() {
-        return clienteRepository.getAll();
+    public List<ClienteDTO> getAllClientes() {
+        List<Cliente> clientes = clienteRepository.getAll();
+        return clientes.stream().map(this::toDTO).toList();
     }
 
     // Recupera um cliente por id
@@ -48,5 +50,8 @@ public class ClienteService {
         clienteRepository.delete(codigo);
     }
 
+    private ClienteDTO toDTO(Cliente cliente) {
+        return new ClienteDTO(cliente.getCodigo(), cliente.getNome(), cliente.getEmail(), cliente.getAssinaturas());
+    }
 }
 

--- a/projArq/src/main/java/com/T1/projArq/domain/services/PagamentoService.java
+++ b/projArq/src/main/java/com/T1/projArq/domain/services/PagamentoService.java
@@ -1,4 +1,4 @@
-package com.T1.projArq.aplication;
+package com.T1.projArq.domain.services;
 
 import com.T1.projArq.domain.model.Assinatura;
 import com.T1.projArq.domain.model.Pagamento;

--- a/projArq/src/main/java/com/T1/projArq/domain/services/PagamentoService.java
+++ b/projArq/src/main/java/com/T1/projArq/domain/services/PagamentoService.java
@@ -1,5 +1,6 @@
 package com.T1.projArq.domain.services;
 
+import com.T1.projArq.application.dto.PagamentoDTO;
 import com.T1.projArq.domain.model.Assinatura;
 import com.T1.projArq.domain.model.Pagamento;
 import com.T1.projArq.domain.repository.IAssinaturaRepository;
@@ -80,12 +81,24 @@ public class PagamentoService {
     }
 
     // Método para obter todos os pagamentos
-    public List<Pagamento> getAll() {
-        return pagamentoRepository.getAll();
+    public List<PagamentoDTO> getAll() {
+        List<Pagamento> pagamentos = pagamentoRepository.getAll();
+
+        // Converte a lista de pagamentos para uma lista de DTOs
+        return pagamentos.stream().map(this::toDTO).toList();
+
     }
 
     // Método para obter um pagamento por id
-    public Pagamento getById(Long codigo) {
-        return pagamentoRepository.getById(codigo);
+    public PagamentoDTO getById(Long codigo) {
+        Pagamento pagamento = pagamentoRepository.getById(codigo);
+        if (pagamento == null) {
+            return null;
+        }
+        return toDTO(pagamento);
+    }
+
+    private PagamentoDTO toDTO(Pagamento pagamento) {
+        return new PagamentoDTO(pagamento.getCodigo(), pagamento.getValorPago(), pagamento.getDataPagamento(), pagamento.getPromocao());
     }
 }

--- a/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/infrastructure/dataBase/AplicativoDataBase.java
+++ b/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/infrastructure/dataBase/AplicativoDataBase.java
@@ -1,4 +1,4 @@
-package com.T1.projArq.infrastructure.dataBase;
+package com.T1.projArq.interfaceAdaptors.infrastructure.dataBase;
 
 import com.T1.projArq.domain.model.Aplicativo;
 import com.T1.projArq.domain.model.Assinatura;

--- a/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/infrastructure/dataBase/AssinaturaDataBase.java
+++ b/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/infrastructure/dataBase/AssinaturaDataBase.java
@@ -68,6 +68,23 @@ public class AssinaturaDataBase implements IAssinaturaRepository {
         });
     }
 
+    public List<Assinatura> getByAplicativoId(Long aplicativoId) {
+        String sql = "SELECT * FROM assinaturas WHERE aplicativo_codigo = ?";
+        return jdbcTemplate.query(sql, new Object[]{aplicativoId}, (rs, rowNum) -> {
+            Long codigo = rs.getLong("codigo");
+            Date inicioVigencia = rs.getDate("inicio_vigencia");
+            Date fimVigencia = rs.getDate("fim_vigencia");
+            Long clienteId = rs.getLong("cliente_codigo");
+
+            Cliente cliente = getClienteById(clienteId);
+            Aplicativo aplicativo = getAplicativoById(aplicativoId);
+            Assinatura assinatura = new Assinatura(codigo, inicioVigencia, fimVigencia, aplicativo, cliente);
+            assinatura.setFimVigencia(fimVigencia);
+
+            return assinatura;
+        });
+    }
+
     @Override
     public void update(Assinatura assinatura) {
         String sql = "UPDATE assinaturas SET inicio_vigencia = ?, fim_vigencia = ?, aplicativo_codigo = ?, cliente_codigo = ? WHERE codigo = ?";

--- a/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/infrastructure/dataBase/AssinaturaDataBase.java
+++ b/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/infrastructure/dataBase/AssinaturaDataBase.java
@@ -50,6 +50,23 @@ public class AssinaturaDataBase implements IAssinaturaRepository {
         });
     }
 
+    public List<Assinatura> getAssinaturaByClienteId(Long clienteId) {
+        String sql = "SELECT * FROM assinaturas WHERE cliente_codigo = ?";
+        return jdbcTemplate.query(sql, new Object[]{clienteId}, (rs, rowNum) -> {
+            Long codigo = rs.getLong("codigo");
+            Date inicioVigencia = rs.getDate("inicio_vigencia");
+            Date fimVigencia = rs.getDate("fim_vigencia");
+            Long aplicativoId = rs.getLong("aplicativo_codigo");
+
+            Cliente cliente = getClienteById(clienteId);
+            Aplicativo aplicativo = getAplicativoById(aplicativoId);
+            Assinatura assinatura = new Assinatura(codigo, inicioVigencia, fimVigencia, aplicativo, cliente);
+            assinatura.setFimVigencia(fimVigencia);
+
+            return assinatura;
+        });
+    }
+
     @Override
     public Assinatura getById(Long codigo) {
         String sql = "SELECT * FROM assinaturas WHERE codigo = ?";
@@ -68,6 +85,7 @@ public class AssinaturaDataBase implements IAssinaturaRepository {
         });
     }
 
+    @Override
     public List<Assinatura> getByAplicativoId(Long aplicativoId) {
         String sql = "SELECT * FROM assinaturas WHERE aplicativo_codigo = ?";
         return jdbcTemplate.query(sql, new Object[]{aplicativoId}, (rs, rowNum) -> {

--- a/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/infrastructure/dataBase/ClienteDataBase.java
+++ b/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/infrastructure/dataBase/ClienteDataBase.java
@@ -1,4 +1,4 @@
-package com.T1.projArq.infrastructure.dataBase;
+package com.T1.projArq.interfaceAdaptors.infrastructure.dataBase;
 
 import com.T1.projArq.domain.model.Aplicativo;
 import com.T1.projArq.domain.model.Assinatura;

--- a/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/infrastructure/dataBase/PagamentoDataBase.java
+++ b/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/infrastructure/dataBase/PagamentoDataBase.java
@@ -1,4 +1,4 @@
-package com.T1.projArq.infrastructure.dataBase;
+package com.T1.projArq.interfaceAdaptors.infrastructure.dataBase;
 
 import com.T1.projArq.domain.model.Aplicativo;
 import com.T1.projArq.domain.model.Assinatura;

--- a/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/presentation/controllers/AplicativoController.java
+++ b/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/presentation/controllers/AplicativoController.java
@@ -1,5 +1,6 @@
 package com.T1.projArq.interfaceAdaptors.presentation.controllers;
 
+import com.T1.projArq.application.dto.AplicativoDTO;
 import com.T1.projArq.domain.model.Aplicativo;
 import com.T1.projArq.domain.services.AplicativoService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,17 +23,17 @@ public class AplicativoController {
     }
 
     @GetMapping
-    public  ResponseEntity<List<Aplicativo>> getAllAplicativos() {
-        List<Aplicativo> aplicativos = aplicativoService.getAllAplicativos();
+    public  ResponseEntity<List<AplicativoDTO>> getAllAplicativos() {
+        List<AplicativoDTO> aplicativos = aplicativoService.getAllAplicativos();
         return new ResponseEntity<>(aplicativos, HttpStatus.OK);
     }
 
     // Cria um aplicativo
     @PostMapping("/atualizacusto/{idAplicativo}")
-    public ResponseEntity<Aplicativo> atualizarCusto(@PathVariable Long idAplicativo, @RequestBody Map<String, Double> request) {
+    public ResponseEntity<AplicativoDTO> atualizarCusto(@PathVariable Long idAplicativo, @RequestBody Map<String, Double> request) {
         Double novoCusto = request.get("custo");
 
-        Aplicativo aplicativoAtualizado = aplicativoService.updateCusto(idAplicativo, novoCusto);
+        AplicativoDTO aplicativoAtualizado = aplicativoService.updateCusto(idAplicativo, novoCusto);
 
         return ResponseEntity.ok(aplicativoAtualizado);
     }

--- a/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/presentation/controllers/AplicativoController.java
+++ b/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/presentation/controllers/AplicativoController.java
@@ -1,11 +1,7 @@
-package com.T1.projArq.presentation.controllers;
+package com.T1.projArq.interfaceAdaptors.presentation.controllers;
 
-import com.T1.projArq.aplication.AplicativoService;
-import com.T1.projArq.aplication.ClienteService;
-import com.T1.projArq.aplication.dto.AplicativoDTO;
-import com.T1.projArq.aplication.dto.ClienteDTO;
 import com.T1.projArq.domain.model.Aplicativo;
-import com.T1.projArq.domain.model.Cliente;
+import com.T1.projArq.domain.services.AplicativoService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/presentation/controllers/AssinaturaController.java
+++ b/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/presentation/controllers/AssinaturaController.java
@@ -1,6 +1,6 @@
 package com.T1.projArq.interfaceAdaptors.presentation.controllers;
 
-import com.T1.projArq.aplication.dto.AssinaturaDTO;
+import com.T1.projArq.application.dto.AssinaturaDTO;
 import com.T1.projArq.domain.services.AssinaturaService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -57,6 +57,16 @@ public class AssinaturaController {
     @GetMapping("/asscli/{codcli}")
     public ResponseEntity<List<AssinaturaDTO>> getAssinaturasByCliente(@PathVariable Long codcli) {
         List<AssinaturaDTO> assinaturas = assinaturaService.getAssinaturasByCliente(codcli);
+
+        if (assinaturas.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(assinaturas);
+    }
+
+    @GetMapping("/assapp/{codapp}")
+    public ResponseEntity<List<AssinaturaDTO>> getAssinaturasByAplicativo(@PathVariable Long codapp) {
+        List<AssinaturaDTO> assinaturas = assinaturaService.getAssinaturasByAplicativo(codapp);
 
         if (assinaturas.isEmpty()) {
             return ResponseEntity.noContent().build();

--- a/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/presentation/controllers/ClienteController.java
+++ b/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/presentation/controllers/ClienteController.java
@@ -1,5 +1,6 @@
 package com.T1.projArq.interfaceAdaptors.presentation.controllers;
 
+import com.T1.projArq.application.dto.ClienteDTO;
 import com.T1.projArq.domain.model.Cliente;
 import com.T1.projArq.domain.services.ClienteService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,8 +22,8 @@ public class ClienteController {
     }
 
     @GetMapping
-    public ResponseEntity<List<Cliente>> getAllClientes() {
-        List<Cliente> clientes = clienteService.getAllClientes();
+    public ResponseEntity<List<ClienteDTO>> getAllClientes() {
+        List<ClienteDTO> clientes = clienteService.getAllClientes();
         return new ResponseEntity<>(clientes, HttpStatus.OK);
     }
 }

--- a/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/presentation/controllers/ClienteController.java
+++ b/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/presentation/controllers/ClienteController.java
@@ -1,16 +1,12 @@
 package com.T1.projArq.interfaceAdaptors.presentation.controllers;
 
-import com.T1.projArq.aplication.ClienteService;
-import com.T1.projArq.aplication.dto.ClienteDTO;
 import com.T1.projArq.domain.model.Cliente;
-import com.T1.projArq.domain.model.Assinatura;
+import com.T1.projArq.domain.services.ClienteService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Date;
 import java.util.List;
 
 @RestController

--- a/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/presentation/controllers/PagamentoController.java
+++ b/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/presentation/controllers/PagamentoController.java
@@ -1,8 +1,8 @@
-package com.T1.projArq.presentation.controllers;
+package com.T1.projArq.interfaceAdaptors.presentation.controllers;
 
-import com.T1.projArq.aplication.PagamentoService;
 import com.T1.projArq.application.dto.PagamentoDTO;
 import com.T1.projArq.domain.model.Pagamento;
+import com.T1.projArq.domain.services.PagamentoService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/presentation/controllers/PagamentoController.java
+++ b/projArq/src/main/java/com/T1/projArq/interfaceAdaptors/presentation/controllers/PagamentoController.java
@@ -38,8 +38,8 @@ public class PagamentoController {
 
     // Obtém todos os pagamentos
     @GetMapping
-    public ResponseEntity<List<Pagamento>> getAllPagamentos() {
-        List<Pagamento> pagamentos = pagamentoService.getAll();
+    public ResponseEntity<List<PagamentoDTO>> getAllPagamentos() {
+        List<PagamentoDTO> pagamentos = pagamentoService.getAll();
         if (pagamentos.isEmpty()) {
             return ResponseEntity.noContent().build();
         }
@@ -48,8 +48,8 @@ public class PagamentoController {
 
     // Obtém um pagamento por ID
     @GetMapping("/{id}")
-    public ResponseEntity<Pagamento> getPagamentoById(@PathVariable Long id) {
-        Pagamento pagamento = pagamentoService.getById(id);
+    public ResponseEntity<PagamentoDTO> getPagamentoById(@PathVariable Long id) {
+        PagamentoDTO pagamento = pagamentoService.getById(id);
         if (pagamento == null) {
             return ResponseEntity.notFound().build();
         }

--- a/projArq/src/main/resources/schema.sql
+++ b/projArq/src/main/resources/schema.sql
@@ -56,7 +56,8 @@ INSERT INTO clientes (codigo, nome, email) VALUES
                                                (7, 'Bruno Pereira', 'bruno.pereira@example.com'),
                                                (8, 'Juliana Ribeiro', 'juliana.ribeiro@example.com'),
                                                (9, 'Ricardo Gomes', 'ricardo.gomes@example.com'),
-                                               (10, 'Tatiane Martins', 'tatiane.martins@example.com');
+                                               (10, 'Tatiane Martins', 'tatiane.martins@example.com'),
+                                               (11, 'Carlos Souza', 'carlos.souza@example.com');
 
 -- Inserções de Aplicativos
 INSERT INTO aplicativos (codigo, nome, custo_mensal) VALUES
@@ -73,4 +74,10 @@ INSERT INTO assinaturas (inicio_vigencia, fim_vigencia, aplicativo_codigo, clien
 ('2024-03-01', '2025-03-01', 3, 3),
 ('2024-04-01', '2025-04-01', 4, 4),
 ('2024-05-01', '2025-05-01', 5, 5),
-('2024-05-01', '2024-06-01', 5, 5);
+('2024-05-01', '2024-06-01', 5, 5),
+('2024-06-01', '2025-06-01', 5, 6),
+('2024-07-01', '2025-07-01', 5, 7),
+('2024-08-01', '2025-08-01', 5, 8),
+('2024-09-01', '2025-09-01', 5, 9),
+('2024-10-01', '2025-10-01', 5, 10),
+('2024-11-01', '2025-11-01', 5, 11);


### PR DESCRIPTION
fixed namespaces that were incorrect/mislabeled
create a new endpoint ( 8 )
converted to dto

*** the most correct way would be the child entities should be also a DTO instead of the entities
i.e. 
 ClienteDTO {
    private Long codigo;
    private String nome;
    private String email;
    private List<Assinatura>
    }
should be 
 ClienteDTO {
    private Long codigo;
    private String nome;
    private String email;
    private List<AssinaturaDTO>
    }

I already created the methods in each entity to convert to dto, but they are all private, but simply changing them to public static and using them when on dto constructor would be enough to fix if we follow that route

FYI: tried to not change much other methods not related to my task, but there a few improvements that could be made using the toDto (just now realized that I named toDTO, which is not camelCase as it is supposed to be) like in getAssinaturasByCliente [file: AssinaturaService.java]

on that note, when retrieving data from the db the best pratice is retriving only the necessary data, making the validation on the query instead of the backend

added a method does this, if we follow that route


on side note for the reviewers: the git lost track of the clienteDto when moving from aplication to application